### PR TITLE
Added Try/Except block for ImportError thrown by parse_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 from setuptools import setup, find_packages
 from os import path
 from json import loads
-from pip.req import parse_requirements
 
+try:
+	from pip._internal.req import parse_requirements
+except ImportError:
+	from pip.req import parse_requirements
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
** pip.req was deprecated in pip v10 in favor of pip._internal.req
** Try/Except attempts to use the latest import scheme first, falling back to the earlier variant if an ImportError is thrown